### PR TITLE
Refactor CSS to remove !important tags

### DIFF
--- a/cmi.postcss
+++ b/cmi.postcss
@@ -1,3 +1,8 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+@tailwind variants;
+
 /*layout elements*/
 
 .app-bar {
@@ -5,15 +10,15 @@
 }
 
 .tab-list {
-	@apply border-b border-neutral-400 !important;
+	@apply border-b border-neutral-400;
 }
 
 .tab-list .border-b-2 {
-	@apply border-b border-neutral-400 !important;
+	@apply border-b border-neutral-400;
 }
 
 .lightswitch-track {
-	@apply ring-surface-700 bg-surface-400 dark:bg-surface-900 !important;
+	@apply ring-surface-700 bg-surface-400 dark:bg-surface-900;
 }
 
 hr {
@@ -23,19 +28,19 @@ hr {
 /*form elements*/
 
 .slide-toggle-track {
-	@apply bg-neutral-200 dark:bg-neutral-600 !important;
+	@apply bg-neutral-200 dark:bg-neutral-600;
 }
 
 input[type=checkbox]:checked + .slide-toggle-track {
-	@apply bg-neutral-300 dark:bg-neutral-800 !important;
+	@apply bg-neutral-300 dark:bg-neutral-800;
 }
 
 .slide-toggle-thumb {
-	@apply bg-neutral-400 dark:bg-neutral-300 !important;
+	@apply bg-neutral-400 dark:bg-neutral-300;
 }
 
 input[type=checkbox]:checked + .slide-toggle-track > .slide-toggle-thumb {
-	@apply bg-neutral-500 dark:bg-neutral-400 !important;
+	@apply bg-neutral-500 dark:bg-neutral-400;
 }
 
 .select,
@@ -44,6 +49,6 @@ input[type=checkbox]:checked + .slide-toggle-track > .slide-toggle-thumb {
 }
 
 input[type='file'] {
-	@apply border-none file:variant-soft-primary hover:file:variant-filled-primary !important;
+	@apply border-none file:variant-soft-primary hover:file:variant-filled-primary;
 }
 

--- a/mockup/src/app.postcss
+++ b/mockup/src/app.postcss
@@ -1,4 +1,0 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-@tailwind variants;

--- a/mockup/src/routes/+layout.svelte
+++ b/mockup/src/routes/+layout.svelte
@@ -17,7 +17,6 @@
 	import typescript from 'highlight.js/lib/languages/typescript';
 	import xml from 'highlight.js/lib/languages/xml';
 	import 'highlight.js/styles/github-dark.css';
-	import '../app.postcss';
 
 	hljs.registerLanguage('xml', xml); // for HTML
 	hljs.registerLanguage('css', css);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmi-dair/skeleton-themes",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "A collection of SkeletonUI themes for CMI.",
   "main": "src/index.ts",
   "scripts": {


### PR DESCRIPTION
This pull request refactors the CSS code to remove the use of !important tags. Dependent repositories will no longer need the skeleton default postCSS import as this will be provided along with the CMI CSS. 